### PR TITLE
Add Prisma users model and CRUD API endpoints

### DIFF
--- a/pos-web-taller-ia/prisma/schema.prisma
+++ b/pos-web-taller-ia/prisma/schema.prisma
@@ -102,9 +102,12 @@ model stores {
 }
 
 model users {
-  id    Int    @id @default(autoincrement())
-  name  String @db.VarChar(100)
-  email String @unique(map: "email") @db.VarChar(100)
+  id             Int      @id @default(autoincrement())
+  correo         String   @unique(map: "correo") @db.VarChar(191)
+  password       String   @db.VarChar(255)
+  activo         Boolean  @default(true)
+  nombre_usuario String   @db.VarChar(120)
+  fecha_creacion DateTime @default(now()) @db.DateTime(0)
 }
 
 enum promotions_promo_type {

--- a/pos-web-taller-ia/src/app/api/login/route.js
+++ b/pos-web-taller-ia/src/app/api/login/route.js
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+
+export async function POST(request) {
+  try {
+    const body = await request.json();
+    const { nombre_usuario, password } = body;
+
+    if (!nombre_usuario || !password) {
+      return NextResponse.json(
+        { message: "nombre_usuario y password son obligatorios." },
+        { status: 400 }
+      );
+    }
+
+    const usuario = await prisma.users.findFirst({
+      where: {
+        nombre_usuario,
+        password,
+        activo: true,
+      },
+    });
+
+    if (!usuario) {
+      return NextResponse.json(
+        { message: "Credenciales inválidas o usuario inactivo." },
+        { status: 401 }
+      );
+    }
+
+    return NextResponse.json({
+      message: "El usuario existe.",
+      usuario: {
+        id: usuario.id,
+        nombre_usuario: usuario.nombre_usuario,
+        correo: usuario.correo,
+      },
+    });
+  } catch (error) {
+    console.error("Error iniciando sesión:", error);
+    return NextResponse.json(
+      { message: "No se pudo procesar el inicio de sesión." },
+      { status: 500 }
+    );
+  }
+}

--- a/pos-web-taller-ia/src/app/api/usuarios/[id]/route.js
+++ b/pos-web-taller-ia/src/app/api/usuarios/[id]/route.js
@@ -1,0 +1,86 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+
+function parseId(params) {
+  const id = Number(params.id);
+  return Number.isInteger(id) && id > 0 ? id : null;
+}
+
+export async function GET(_request, { params }) {
+  const id = parseId(params);
+
+  if (!id) {
+    return NextResponse.json({ message: "Identificador inválido." }, { status: 400 });
+  }
+
+  try {
+    const usuario = await prisma.users.findUnique({ where: { id } });
+
+    if (!usuario) {
+      return NextResponse.json({ message: "Usuario no encontrado." }, { status: 404 });
+    }
+
+    return NextResponse.json(usuario);
+  } catch (error) {
+    console.error("Error obteniendo usuario:", error);
+    return NextResponse.json({ message: "No se pudo obtener el usuario." }, { status: 500 });
+  }
+}
+
+export async function PUT(request, { params }) {
+  const id = parseId(params);
+
+  if (!id) {
+    return NextResponse.json({ message: "Identificador inválido." }, { status: 400 });
+  }
+
+  try {
+    const body = await request.json();
+    const { correo, password, nombre_usuario, activo } = body;
+
+    const data = {};
+    if (correo !== undefined) data.correo = correo;
+    if (password !== undefined) data.password = password;
+    if (nombre_usuario !== undefined) data.nombre_usuario = nombre_usuario;
+    if (activo !== undefined) data.activo = Boolean(activo);
+
+    if (Object.keys(data).length === 0) {
+      return NextResponse.json(
+        { message: "No se proporcionaron campos para actualizar." },
+        { status: 400 }
+      );
+    }
+
+    const usuario = await prisma.users.update({
+      where: { id },
+      data,
+    });
+
+    return NextResponse.json(usuario);
+  } catch (error) {
+    console.error("Error actualizando usuario:", error);
+    if (error.code === "P2025") {
+      return NextResponse.json({ message: "Usuario no encontrado." }, { status: 404 });
+    }
+    return NextResponse.json({ message: "No se pudo actualizar el usuario." }, { status: 500 });
+  }
+}
+
+export async function DELETE(_request, { params }) {
+  const id = parseId(params);
+
+  if (!id) {
+    return NextResponse.json({ message: "Identificador inválido." }, { status: 400 });
+  }
+
+  try {
+    await prisma.users.delete({ where: { id } });
+    return NextResponse.json({ message: "Usuario eliminado correctamente." });
+  } catch (error) {
+    console.error("Error eliminando usuario:", error);
+    if (error.code === "P2025") {
+      return NextResponse.json({ message: "Usuario no encontrado." }, { status: 404 });
+    }
+    return NextResponse.json({ message: "No se pudo eliminar el usuario." }, { status: 500 });
+  }
+}

--- a/pos-web-taller-ia/src/app/api/usuarios/route.js
+++ b/pos-web-taller-ia/src/app/api/usuarios/route.js
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+
+export async function GET() {
+  try {
+    const usuarios = await prisma.users.findMany({
+      orderBy: { id: "asc" },
+    });
+
+    return NextResponse.json(usuarios);
+  } catch (error) {
+    console.error("Error fetching usuarios:", error);
+    return NextResponse.json(
+      { message: "No se pudieron obtener los usuarios." },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request) {
+  try {
+    const body = await request.json();
+    const { correo, password, nombre_usuario, activo = true } = body;
+
+    if (!correo || !password || !nombre_usuario) {
+      return NextResponse.json(
+        { message: "correo, password y nombre_usuario son obligatorios." },
+        { status: 400 }
+      );
+    }
+
+    const usuario = await prisma.users.create({
+      data: {
+        correo,
+        password,
+        nombre_usuario,
+        activo: Boolean(activo),
+      },
+    });
+
+    return NextResponse.json(usuario, { status: 201 });
+  } catch (error) {
+    console.error("Error creando usuario:", error);
+    return NextResponse.json(
+      { message: "No se pudo crear el usuario." },
+      { status: 500 }
+    );
+  }
+}

--- a/pos-web-taller-ia/src/app/page.js
+++ b/pos-web-taller-ia/src/app/page.js
@@ -1,103 +1,116 @@
-import Image from "next/image";
+"use client";
+
+import { useState } from "react";
 
 export default function Home() {
-  return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              src/app/page.js
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
+  const [nombreUsuario, setNombreUsuario] = useState("");
+  const [password, setPassword] = useState("");
+  const [mensaje, setMensaje] = useState("");
+  const [error, setError] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setMensaje("");
+    setError("");
+
+    if (!nombreUsuario || !password) {
+      setError("Ingresa usuario y contraseña.");
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const response = await fetch("/api/login", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ nombre_usuario: nombreUsuario, password }),
+      });
+
+      const data = await response.json();
+
+      if (response.ok) {
+        setMensaje(data.message ?? "El usuario existe.");
+      } else {
+        setError(data.message ?? "No se pudo iniciar sesión.");
+      }
+    } catch (fetchError) {
+      console.error("Error al iniciar sesión:", fetchError);
+      setError("Ocurrió un error al iniciar sesión.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-slate-100 p-4">
+      <div className="w-full max-w-md rounded-lg bg-white p-8 shadow">
+        <h1 className="text-2xl font-semibold text-slate-900 text-center mb-6">
+          Iniciar sesión
+        </h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label
+              htmlFor="nombre_usuario"
+              className="block text-sm font-medium text-slate-700"
+            >
+              Usuario
+            </label>
+            <input
+              id="nombre_usuario"
+              name="nombre_usuario"
+              type="text"
+              value={nombreUsuario}
+              onChange={(event) => setNombreUsuario(event.target.value)}
+              className="mt-1 block w-full rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500"
+              placeholder="Ingresa tu usuario"
+              autoComplete="username"
             />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
+          </div>
+
+          <div>
+            <label
+              htmlFor="password"
+              className="block text-sm font-medium text-slate-700"
+            >
+              Contraseña
+            </label>
+            <input
+              id="password"
+              name="password"
+              type="password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              className="mt-1 block w-full rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500"
+              placeholder="Ingresa tu contraseña"
+              autoComplete="current-password"
+            />
+          </div>
+
+          {mensaje && (
+            <p className="rounded-md bg-green-50 px-3 py-2 text-sm text-green-800">
+              {mensaje}
+            </p>
+          )}
+
+          {error && (
+            <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-800">
+              {error}
+            </p>
+          )}
+
+          <button
+            type="submit"
+            className="w-full rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white shadow hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2"
+            disabled={isSubmitting}
           >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
+            {isSubmitting ? "Verificando..." : "Ingresar"}
+          </button>
+        </form>
+      </div>
     </div>
   );
 }

--- a/pos-web-taller-ia/src/lib/prisma.js
+++ b/pos-web-taller-ia/src/lib/prisma.js
@@ -1,0 +1,11 @@
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = globalThis;
+
+const prisma = globalForPrisma.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma;
+}
+
+export default prisma;


### PR DESCRIPTION
## Summary
- expand the Prisma `users` model with correo, password, activo, nombre_usuario y fecha_creacion fields for MySQL
- add a shared Prisma client helper and Next.js API routes providing CRUD operations for usuarios

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ddb9f98dd4832f9343314b229bb605