### PR TITLE
Add demo login seeding and secure password handling

### DIFF
--- a/pos-web-taller-ia/prisma/schema.prisma
+++ b/pos-web-taller-ia/prisma/schema.prisma
@@ -102,9 +102,12 @@ model stores {
 }
 
 model users {
-  id    Int    @id @default(autoincrement())
-  name  String @db.VarChar(100)
-  email String @unique(map: "email") @db.VarChar(100)
+  id             Int      @id @default(autoincrement())
+  correo         String   @unique(map: "correo") @db.VarChar(191)
+  password       String   @db.VarChar(255)
+  activo         Boolean  @default(true)
+  nombre_usuario String   @db.VarChar(120)
+  fecha_creacion DateTime @default(now()) @db.DateTime(0)
 }
 
 enum promotions_promo_type {

--- a/pos-web-taller-ia/src/app/api/login/route.js
+++ b/pos-web-taller-ia/src/app/api/login/route.js
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { verifyPassword } from "@/lib/password";
+
+export async function POST(request) {
+  try {
+    const body = await request.json();
+    const { nombre_usuario, password } = body;
+
+    if (!nombre_usuario || !password) {
+      return NextResponse.json(
+        { message: "nombre_usuario y password son obligatorios." },
+        { status: 400 }
+      );
+    }
+
+    const usuario = await prisma.users.findFirst({
+      where: {
+        nombre_usuario,
+        activo: true,
+      },
+      select: {
+        id: true,
+        nombre_usuario: true,
+        correo: true,
+        password: true,
+      },
+    });
+
+    if (!usuario) {
+      return NextResponse.json(
+        { message: "Credenciales inválidas o usuario inactivo." },
+        { status: 401 }
+      );
+    }
+
+    const passwordCorrecto = await verifyPassword(password, usuario.password);
+
+    if (!passwordCorrecto) {
+      return NextResponse.json(
+        { message: "Credenciales inválidas o usuario inactivo." },
+        { status: 401 }
+      );
+    }
+
+    const response = NextResponse.json({
+      message: "Inicio de sesión exitoso.",
+      usuario: {
+        id: usuario.id,
+        nombre_usuario: usuario.nombre_usuario,
+        correo: usuario.correo,
+      },
+    });
+
+    response.cookies.set("session_user", String(usuario.id), {
+      httpOnly: true,
+      sameSite: "lax",
+      maxAge: 60 * 60 * 24,
+      secure: process.env.NODE_ENV === "production",
+      path: "/",
+    });
+
+    return response;
+  } catch (error) {
+    console.error("Error iniciando sesión:", error);
+    return NextResponse.json(
+      { message: "No se pudo procesar el inicio de sesión." },
+      { status: 500 }
+    );
+  }
+}

--- a/pos-web-taller-ia/src/app/api/test-user/route.js
+++ b/pos-web-taller-ia/src/app/api/test-user/route.js
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { hashPassword } from "@/lib/password";
+
+const DEMO_USER = {
+  correo: "demo@example.com",
+  nombre_usuario: "demo",
+  password: "Demo1234",
+};
+
+export async function GET() {
+  try {
+    const hashedPassword = await hashPassword(DEMO_USER.password);
+
+    const usuario = await prisma.users.upsert({
+      where: { correo: DEMO_USER.correo },
+      update: {
+        nombre_usuario: DEMO_USER.nombre_usuario,
+        password: hashedPassword,
+        activo: true,
+      },
+      create: {
+        correo: DEMO_USER.correo,
+        nombre_usuario: DEMO_USER.nombre_usuario,
+        password: hashedPassword,
+        activo: true,
+      },
+    });
+
+    return NextResponse.json({
+      message: "Usuario de demostración listo para iniciar sesión.",
+      usuario: {
+        id: usuario.id,
+        correo: usuario.correo,
+        nombre_usuario: usuario.nombre_usuario,
+        activo: usuario.activo,
+      },
+      credenciales: {
+        usuario: DEMO_USER.nombre_usuario,
+        password: DEMO_USER.password,
+      },
+    });
+  } catch (error) {
+    console.error("Error creando usuario de prueba:", error);
+    return NextResponse.json(
+      { message: "No se pudo preparar el usuario de demostración." },
+      { status: 500 }
+    );
+  }
+}

--- a/pos-web-taller-ia/src/app/api/usuarios/[id]/route.js
+++ b/pos-web-taller-ia/src/app/api/usuarios/[id]/route.js
@@ -1,0 +1,136 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { hashPassword } from "@/lib/password";
+
+function parseId(params) {
+  const id = Number(params.id);
+  return Number.isInteger(id) && id > 0 ? id : null;
+}
+
+export async function GET(_request, { params }) {
+  const id = parseId(params);
+
+  if (!id) {
+    return NextResponse.json({ message: "Identificador inválido." }, { status: 400 });
+  }
+
+  try {
+    const usuario = await prisma.users.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        correo: true,
+        nombre_usuario: true,
+        activo: true,
+        fecha_creacion: true,
+      },
+    });
+
+    if (!usuario) {
+      return NextResponse.json({ message: "Usuario no encontrado." }, { status: 404 });
+    }
+
+    return NextResponse.json(usuario);
+  } catch (error) {
+    console.error("Error obteniendo usuario:", error);
+    return NextResponse.json({ message: "No se pudo obtener el usuario." }, { status: 500 });
+  }
+}
+
+export async function PUT(request, { params }) {
+  const id = parseId(params);
+
+  if (!id) {
+    return NextResponse.json({ message: "Identificador inválido." }, { status: 400 });
+  }
+
+  try {
+    const body = await request.json();
+    const { correo, password, nombre_usuario, activo } = body;
+
+    const data = {};
+    if (correo !== undefined) {
+      const correoNormalizado = correo.trim().toLowerCase();
+      if (!correoNormalizado) {
+        return NextResponse.json(
+          { message: "correo no puede estar vacío." },
+          { status: 400 }
+        );
+      }
+      data.correo = correoNormalizado;
+    }
+    if (password !== undefined) {
+      if (!password) {
+        return NextResponse.json(
+          { message: "password no puede estar vacío." },
+          { status: 400 }
+        );
+      }
+      try {
+        data.password = await hashPassword(password);
+      } catch (hashError) {
+        return NextResponse.json(
+          { message: hashError.message ?? "La contraseña no es válida." },
+          { status: 400 }
+        );
+      }
+    }
+    if (nombre_usuario !== undefined) {
+      const nombreUsuarioNormalizado = nombre_usuario.trim();
+      if (!nombreUsuarioNormalizado) {
+        return NextResponse.json(
+          { message: "nombre_usuario no puede estar vacío." },
+          { status: 400 }
+        );
+      }
+      data.nombre_usuario = nombreUsuarioNormalizado;
+    }
+    if (activo !== undefined) data.activo = Boolean(activo);
+
+    if (Object.keys(data).length === 0) {
+      return NextResponse.json(
+        { message: "No se proporcionaron campos para actualizar." },
+        { status: 400 }
+      );
+    }
+
+    const usuario = await prisma.users.update({
+      where: { id },
+      data,
+      select: {
+        id: true,
+        correo: true,
+        nombre_usuario: true,
+        activo: true,
+        fecha_creacion: true,
+      },
+    });
+
+    return NextResponse.json(usuario);
+  } catch (error) {
+    console.error("Error actualizando usuario:", error);
+    if (error.code === "P2025") {
+      return NextResponse.json({ message: "Usuario no encontrado." }, { status: 404 });
+    }
+    return NextResponse.json({ message: "No se pudo actualizar el usuario." }, { status: 500 });
+  }
+}
+
+export async function DELETE(_request, { params }) {
+  const id = parseId(params);
+
+  if (!id) {
+    return NextResponse.json({ message: "Identificador inválido." }, { status: 400 });
+  }
+
+  try {
+    await prisma.users.delete({ where: { id } });
+    return NextResponse.json({ message: "Usuario eliminado correctamente." });
+  } catch (error) {
+    console.error("Error eliminando usuario:", error);
+    if (error.code === "P2025") {
+      return NextResponse.json({ message: "Usuario no encontrado." }, { status: 404 });
+    }
+    return NextResponse.json({ message: "No se pudo eliminar el usuario." }, { status: 500 });
+  }
+}

--- a/pos-web-taller-ia/src/app/api/usuarios/route.js
+++ b/pos-web-taller-ia/src/app/api/usuarios/route.js
@@ -1,0 +1,79 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { hashPassword } from "@/lib/password";
+
+export async function GET() {
+  try {
+    const usuarios = await prisma.users.findMany({
+      orderBy: { id: "asc" },
+      select: {
+        id: true,
+        correo: true,
+        nombre_usuario: true,
+        activo: true,
+        fecha_creacion: true,
+      },
+    });
+
+    return NextResponse.json(usuarios);
+  } catch (error) {
+    console.error("Error fetching usuarios:", error);
+    return NextResponse.json(
+      { message: "No se pudieron obtener los usuarios." },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request) {
+  try {
+    const body = await request.json();
+    const { correo, password, nombre_usuario, activo = true } = body;
+
+    if (!correo || !password || !nombre_usuario) {
+      return NextResponse.json(
+        { message: "correo, password y nombre_usuario son obligatorios." },
+        { status: 400 }
+      );
+    }
+
+    const correoNormalizado = correo.trim().toLowerCase();
+    const nombreUsuarioNormalizado = nombre_usuario.trim();
+
+    if (!correoNormalizado || !nombreUsuarioNormalizado) {
+      return NextResponse.json(
+        { message: "correo y nombre_usuario no pueden estar vacíos." },
+        { status: 400 }
+      );
+    }
+
+    let hashedPassword;
+    try {
+      hashedPassword = await hashPassword(password);
+    } catch (hashError) {
+      return NextResponse.json(
+        { message: hashError.message ?? "La contraseña no es válida." },
+        { status: 400 }
+      );
+    }
+
+    const usuario = await prisma.users.create({
+      data: {
+        correo: correoNormalizado,
+        password: hashedPassword,
+        nombre_usuario: nombreUsuarioNormalizado,
+        activo: Boolean(activo),
+      },
+    });
+
+    const { password: _password, ...usuarioSeguro } = usuario;
+
+    return NextResponse.json(usuarioSeguro, { status: 201 });
+  } catch (error) {
+    console.error("Error creando usuario:", error);
+    return NextResponse.json(
+      { message: "No se pudo crear el usuario." },
+      { status: 500 }
+    );
+  }
+}

--- a/pos-web-taller-ia/src/lib/password.js
+++ b/pos-web-taller-ia/src/lib/password.js
@@ -1,0 +1,41 @@
+import { randomBytes, scrypt as scryptCallback, timingSafeEqual } from "node:crypto";
+import { promisify } from "node:util";
+
+const scrypt = promisify(scryptCallback);
+const KEY_LENGTH = 64;
+
+export async function hashPassword(password) {
+  if (typeof password !== "string" || password.length === 0) {
+    throw new Error("La contraseña no puede estar vacía.");
+  }
+
+  const salt = randomBytes(16).toString("hex");
+  const derivedKey = await scrypt(password, salt, KEY_LENGTH);
+  return `${salt}:${Buffer.from(derivedKey).toString("hex")}`;
+}
+
+export async function verifyPassword(password, hashedPassword) {
+  if (!hashedPassword) {
+    return false;
+  }
+
+  const [salt, key] = hashedPassword.split(":");
+  if (!salt || !key) {
+    return false;
+  }
+
+  try {
+    const derivedKey = await scrypt(password, salt, KEY_LENGTH);
+    const derivedBuffer = Buffer.from(derivedKey);
+    const keyBuffer = Buffer.from(key, "hex");
+
+    if (derivedBuffer.length !== keyBuffer.length) {
+      return false;
+    }
+
+    return timingSafeEqual(derivedBuffer, keyBuffer);
+  } catch (error) {
+    console.error("Error verificando contraseña:", error);
+    return false;
+  }
+}

--- a/pos-web-taller-ia/src/lib/prisma.js
+++ b/pos-web-taller-ia/src/lib/prisma.js
@@ -1,0 +1,11 @@
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = globalThis;
+
+const prisma = globalForPrisma.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma;
+}
+
+export default prisma;


### PR DESCRIPTION
## Summary
- add a shared password helper that hashes credentials with Node's crypto APIs and reuse it across the login and user CRUD endpoints
- tighten the login and user API routes to work with hashed passwords, sanitize input, and hide password hashes from responses while setting a simple session cookie on successful login
- add a /api/test-user endpoint plus UI messaging that prepares demo credentials so the login screen can be tested immediately

## Testing
- npm run lint *(hangs in this environment; command had to be interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68ddb9f98dd4832f9343314b229bb605